### PR TITLE
Validation for severity level

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -428,7 +428,7 @@ module.exports = {
                 }
             } else if (path.startsWith('root.containers.cna.metrics') && path.endsWith(".other")) {
                 if (!value.content) {
-                    errors.push({path: "root.containers.cna.metrics", property: 'format', message: 'Severity level is required'});
+                    errors.push({path: path.replaceAll(".other", "") + ".oneOf[1].other.content.text", property: 'format', message: 'Severity level is required'});
                 }
             }
             return errors;


### PR DESCRIPTION
This adds custom validation that when an 'other' metrics is added, it needs to be filled.

Shouldn't this already have been caught by the 'default' validation via the schema though?

This does not yet validate that there is exactly one metric, that that metric is of type 'other', or that the value is one of the four common severity levels.

Fixes #50