### PR TITLE
Send main commit notifications to private@security

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+notifications:
+  commits: private@security.apache.org
+  pullrequests: private@security.apache.org


### PR DESCRIPTION
Instead of security@apache.org
See also INFRA-24118