### PR TITLE
Correctly show red border when severity level is missing

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -433,7 +433,7 @@ module.exports = {
                 }
             } else if (path.startsWith('root.containers.cna.metrics') && path.endsWith(".other")) {
                 if (!value.content) {
-                    errors.push({path: "root.containers.cna.metrics", property: 'format', message: 'Severity level is required'});
+                    errors.push({path: path.replaceAll(".other", "") + ".oneOf[1].other.content.text", property: 'format', message: 'Severity level is required'});
                 }
             }
             return errors;


### PR DESCRIPTION
By correctly specifying the path to the 'oneOf' box.

This was reviewed earlier in #51, but that was still targeting the old branch. Tested locally.