### PR TITLE
Send comment notifications in plain text

### DIFF
--- a/custom/asf.js
+++ b/custom/asf.js
@@ -299,7 +299,7 @@ var self = module.exports = {
                               "cc": "security@apache.org", 
                               "bcc": req.user.email,
 			      "subject":"Comment added on "+req.body.id,
-			      "text":req.body.text+"\n\n"+url}).then( (x) => {  console.log("sent notification mail "+x);});        
+			      "text":req.body.plainText+"\n\n"+url}).then( (x) => {  console.log("sent notification mail "+x);});
     },
 
     asfhookaddhistory: function(oldDoc, newDoc) {

--- a/public/js/comment.js
+++ b/public/js/comment.js
@@ -3,7 +3,8 @@
 async function sendComment(f) {
     var comment = {
         id: f.id.value,
-        text: f.commentarea.innerHTML
+        text: f.commentarea.innerHTML,
+        plainText: htmltoText(f.commentarea.innerHTML)
     };
     if (f.slug && f.slug.value) {
         comment.slug = f.slug.value;


### PR DESCRIPTION
We are currently sending HTML emails with text/plain content-type, which is ugly. Let's just send plaintext email.

Fixes #71 