### PR TITLE
Recommend explicitly mentioning the fixed version in the description

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -67,6 +67,18 @@ module.exports = {
             "orgId" : {
                 "template": conf.cveorgid
             },
+            "cnaPublishedContainer": {
+                "properties": {
+                    "descriptions": {
+                        "default": {
+                            "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR].\nUsers are recommended to upgrade to version [FIXED_VERSION], which fixes this issue.",
+                            "supportingMedia": [ {
+                                "value": "[PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] on [PLATFORMS] allows [ATTACKER] to [IMPACT] via [VECTOR].<br>Users are recommended to upgrade to version [FIXED_VERSION], which fixes this issue."
+                            } ]
+                        },
+                    }
+                }
+            }
         },
         
         "title":" ",

--- a/default/cve5/cvelist.pug
+++ b/default/cve5/cvelist.pug
@@ -274,19 +274,19 @@ mixin autoText
     |  vulnerability
     - var codelist = [];
     - var relevantList = [];
+    - var fixedVersion = '[FIXED_VERSION]';
     if con.affected
         - var plist = [];
         for p in con.affected
-            - var pd = [p.vendor, p.vendor != p.product ? p.product : '', p.packageName != p.product ? p.packageName : '', (p.platforms ? 'on ' + p.platforms.join(', ') : ''), p.modules ? '(' + p.modules.join(', ') + ' modules)':''].join(' ').trim().replaceAll(/\s+/g, ' ')
             - var pn = p.product ? p.product : p.packageName;
-            if pd
-                - plist.push(pd);
+            - plist.push(pn);
             if p.versions
                 - var vlist = [];
                 for v in p.versions
                     if v.status == 'affected'
                         if v.lessThan
                             - vlist.push ( (v.version != '0' ? ' from ' + v.version: '') + (v.lessThan != '*' ? ' before ' + v.lessThan:''));
+                            - fixedVersion = v.lessThan
                         else if v.lessThanOrEqual
                             - vlist.push ( (v.version != '0' ? ' from ' + v.version: '') + (v.lessThanOrEqual != '*' ? ' through ' + v.lessThanOrEqual:''));
                         else if v.version != '0'
@@ -348,6 +348,10 @@ mixin autoText
             p This issue affects 
                 = relevantList.join('; ')
                 |.
+        if fixedVersion
+            p Users are recommended to upgrade to version 
+                = fixedVersion
+                |, which fixes the issue.
 
 block red
     if ctemplate != undefined


### PR DESCRIPTION
This actionable information is currently often missed in our descriptions.

https://www.openwall.com/lists/oss-security/2023/01/31/7
https://www.openwall.com/lists/oss-security/2022/10/12/2
https://www.openwall.com/lists/oss-security/2022/08/26/4
https://www.openwall.com/lists/oss-security/2022/01/25/15

(this is probably because this is obvious to us, since we publish CVE's after releasing the fixed version. That convention is not universal, though, so it is useful to call it out explicitly)