### PR TITLE
Avoid repeating a URL in the HTML to text conversion

### DIFF
--- a/default/cve5/script.js
+++ b/default/cve5/script.js
@@ -361,6 +361,7 @@ function htmltoText(html) {
         //text = text.replace(/\n/gi, "");
         text = text.replace(/<style([\s\S]*?)<\/style[^>]*?>/gi, "");
         text = text.replace(/<script([\s\S]*?)<\/script[^>]*?>/gi, "");
+        text = text.replace(/<a.*?href="(.*?)[\?\"].*?>\1<\/a.*?>/gi, " $1 ");
         text = text.replace(/<a.*?href="(.*?)[\?\"].*?>(.*?)<\/a.*?>/gi, " $2 $1 ");
         text = text.replace(/<\/div[^>]*?>/gi, "\n\n");
         text = text.replace(/<\/li[^>]*?>/gi, "\n");


### PR DESCRIPTION
When you type a URL into the WYSIWYG editor, it gets converted to a link automatically. However, when it is then converted to plain text, htmltoText produces the URL twice: once as the 'link text' and once as the link itself.

This change makes sure that if the link text is identical to the link itself, it is not repeated.