### PR TITLE
Enable 'tags' field

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -392,9 +392,7 @@ module.exports = {
                                 "title": "Credits (optional, please use if externally reported issue)",
                             },
                             "tags": {
-                                "options": {
-			            "hidden": "true"
-                                }
+                                "title": "Tags (optional, only 'unsupported-when-assigned' is relevant for Apache)"
                             },
                             "taxonomyMappings": {
                                 "options": {


### PR DESCRIPTION
To be able to set the 'unsupported when assigned' tag, https://www.cve.org/Resources/General/End-of-Life-EOL-Assignment-Process.pdf