### PR TITLE
Resolve HTML entities in comment notification emails

### DIFF
--- a/public/js/comment.js
+++ b/public/js/comment.js
@@ -4,7 +4,7 @@ async function sendComment(f) {
     var comment = {
         id: f.id.value,
         text: f.commentarea.innerHTML,
-        plainText: htmltoText(f.commentarea.innerHTML)
+        plainText: domhtml(f.commentarea.innerHTML)
     };
     if (f.slug && f.slug.value) {
         comment.slug = f.slug.value;


### PR DESCRIPTION
Previously (since https://github.com/apache/security-vulnogram/pull/76), we used `htmltoText` to send notification emails in plain text. While that worked, HTML entities would still show up in HTML. Using `domhtml` will also convert the entities.