### PR TITLE
Fix ASF list validation

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -483,13 +483,13 @@ module.exports = {
                     errors.push({path: path.replaceAll(".other", "") + ".oneOf[1].other.content.text", property: 'format', message: 'Severity level is required'});
                 }
             } else if (path.startsWith('root.CNA_private.userslist')) {
-                value.split(/[ ,]+/).forEach(address => {
+                value.trim().split(/[ ,]+/).forEach(address => {
                     if (address == "announce@apache.org") {
                         errors.push({path: 'root', property: 'format', message: 'Do not add announce@apache.org to the mailinglists, it will be included automatically.'})
                     } else if (address == "oss-security@lists.openwall.com") {
                         errors.push({path: 'root', property: 'format', message: 'Do not add oss-security to the mailinglists, it will be notified separately.'})
                     } else if (!address.endsWith('.apache.org')) {
-                        errors.push({path: 'root', property: 'format', message: 'Notification list is not an ASFlist.'})
+                        errors.push({path: 'root', property: 'format', message: 'Notification list is not an ASF list.'})
                     }
                 })
             }


### PR DESCRIPTION
Don't show a warning when there's trailing whitespace (seen at https://cveprocess.apache.org:3555/cve5/CVE-2022-47501#editor)