### PR TITLE
Hide 'defaultStatus' field

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -300,6 +300,11 @@ module.exports = {
                                                 },
                                             },
                                         },
+                                        "defaultStatus": {
+                                            "options": {
+                                                "hidden": "true",
+                                            }
+                                        },
                                         "repo": {
                                             "options": {
                                                 "hidden": "true",


### PR DESCRIPTION
The 'defaultStatus' field leads to confusion, with some projects accidentally setting it to 'y' leading to a version range that would consider any version as 'affected'.

Hiding the 'defaultStatus' field will remove the entry from the CVE JSON entirely for new CVEs. This seems OK: the schema says either defaultStatus or a 'versions' section is required[0], and the docs for the versions[1] say "When defaultStatus is itself omitted, it defaults to unknown", which seems reasonable.

[0] https://github.com/CVEProject/cve-schema/blame/master/schema/v5.0/CVE_JSON_5.0_schema.json#L104
[1] https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/versions.md#version-status-decisions

Fixes #118