### PR TITLE
Add `sameSite` option for cookie

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,7 +94,8 @@ app.use(session({
     saveUninitialized: false,
     cookie: {
       secure: process.env.NODE_ENV == "production",
-      httpOnly: true
+      httpOnly: true,
+      sameSite: 'strict',
     }
 }));
 


### PR DESCRIPTION
This helps protect against potential XSS attacks. It *seems* to work OK for me locally, but it is possible that it breaks the OAuth login - this is tricky to test because I don't have HTTPS enabled when testing locally.

To test on the deployed test environment after merging and before moving to prod. If this doesn't work 'lax' might be a second-best setting.