### PR TITLE
loosen cookie sameSite setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ app.use(session({
     cookie: {
       secure: process.env.NODE_ENV == "production",
       httpOnly: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
     }
 }));
 


### PR DESCRIPTION
this is the easiest way be able to 'remember' the CVE you were going to before getting redirected to the login.

follow-up on #132