### PR TITLE
remove validation that versionType is empty for non-ranges

### DIFF
--- a/default/cve5/conf.js
+++ b/default/cve5/conf.js
@@ -331,13 +331,6 @@ module.exports = {
                         message: 'Version type is required for ranges'
                     });
                 }
-                if(value.lessThan == undefined && value.lessThanOrEqual == undefined && value.version != undefined && value.versionType != undefined) {
-                    errors.push({
-                        path: path+'.versionType',
-                        property: 'format',
-                        message: 'Version type is used only for ranges. Clear this or define a range'
-                    });
-                }
                 if(value.lessThan == undefined && value.lessThanOrEqual == undefined && value.version != undefined && value.changes != undefined) {
                     errors.push({
                         path: path+'.changes',


### PR DESCRIPTION
Having a versionType for single versions should be allowed since 2022 (https://github.com/CVEProject/cve-schema/issues/201), and this should fix #141

Manually checked with CVE-2023-49198 that cve.org also accepts this.

Also proposed upstream in https://github.com/Vulnogram/Vulnogram/pull/234