### PR TITLE
send emails after saving the CVE

### DIFF
--- a/custom/cve5/edit.pug
+++ b/custom/cve5/edit.pug
@@ -230,14 +230,14 @@ block customtabs
                 div#asfemail
 
             p
-            form.rnd(method='POST', action='/sendemails', onclick="var j=mainTabGroup.getValue(); j.CNA_private.emailed='yes';save()")
+            form.rnd(method='POST', action='/sendemails')
                input(type='hidden', name='_csrf', value=csrfToken)
                input(type='hidden',name='emailtext',id='emailtext')
                input(type='hidden',name='emailsubject',id='emailsubject')
                input(type='hidden',name='emailreplyto',id='emailreplyto')
                input(type='hidden',name='emailto1',id='emailto1')
                input(type='hidden',name='emailto2',id='emailto2')               
-               button.btn.sfe(disabled='true', type='submit', value='Email', id='emailbutton') Send these Emails
+               button.btn.sfe(disabled='true', type='button', value='Email', id='emailbutton', onclick='var j=mainTabGroup.getValue(); j.CNA_private.emailed="yes";save(undefined, function(){form.submit();});') Send these Emails
                div#emailbuttonnote               
 
 block append customtabs

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -1328,7 +1328,7 @@ function loadJSON(res, id, message, editorOptions) {
     });
 }
 
-function save() {
+function save(e, onSuccess) {
     var j = mainTabGroup.getValue();
     if (!j){
         return;
@@ -1369,6 +1369,8 @@ function save() {
                     save1.className = "fbn sfe";
                 }
                 getChanges(getDocID());
+                if (onSuccess)
+                    onSuccess()
             }
             changes = 0;
         })


### PR DESCRIPTION
Previously, when using the 'Send these Emails' button on the 'OSS/ASF Emails' tab, the CVE was saved with the 'CNA_private.emailed' flag enabled, and in parallel the form to trigger the emails was submitted.

This change makes those two actions sequential: first save the CVE (with the 'emailed' flag set to 'yes'), then post the form.

This fixes https://github.com/apache/security-vulnogram/issues/115 , both the fact that an error box was briefly shown, and the fact that sometimes the 'emailed' flag would not get set to 'yes' correctly.

A downside of this issue is that in case of failure to send the emails, the 'emailed' flag will still be set to 'yes'. That seems acceptable to me: I don't think it has happened much, and when it does it's easy enough to reset the flag on the 'Source' tab.

I've proposed the change to `public/js/editor.js` upstream at https://github.com/Vulnogram/Vulnogram/pull/235