### PR TITLE
improve input placeholder text contrast

### DIFF
--- a/public/css/min.css
+++ b/public/css/min.css
@@ -456,7 +456,8 @@ box-shadow: 0 0 0 0.2em rgba(147, 147, 147, 0.3);
     background-color: var(--wht);
 }
 ::placeholder {
-    color: var(--bor2);
+    color: #111;
+    font-style: italic;
 }
 .txt:disabled {
     background-color: var(--wht);


### PR DESCRIPTION
making it italic to make it distinct from 'actual' input

fixes #143

before (focus on the version ranges)

![out](https://github.com/user-attachments/assets/9f490fcc-24ef-4545-bb52-4e3f3033e4ad)

after:

![out](https://github.com/user-attachments/assets/898792d4-9c1f-4bdb-87d2-5ebe02e0de06)

/cc @martin-g