### PR TITLE
problemType: autocomplete all CWEs

### DIFF
--- a/custom/cve5/conf.js
+++ b/custom/cve5/conf.js
@@ -181,12 +181,6 @@ module.exports = {
                                 }                                
                             },
                             "problemTypes": {
-                                "links": [ {
-                                    "class": "lbl vgi-ext",
-                                    "place": "header",
-                                    "rel": "'to be selected from the CWE-1003 view (autocompleted)'",
-                                    "href": "'https://cwe.mitre.org/data/definitions/1003.html'"
-                                } ],
                                 "items": {
                                     "properties": {
                                         "descriptions": {
@@ -197,7 +191,8 @@ module.exports = {
                                                             "inputAttributes": {
                                                                 "placeholder": "Vulnerability type: can be a pull-down CWE or free text"
                                                             }
-                                                        }
+                                                        },
+                                                        "$ref": "js/cwe-all.json"
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
The NVD has clarified that they highly encourage us to begin providing CWE values that are outside the CWE-1003 to be more granular with our CWE assertions. Should there be clarity concerns or improper negative impacts to our CVMAP assessment results, we can discuss those as they arise and make adjustments to our understandings or processes as needed.