### PR TITLE
Add packageName to notification email

### DIFF
--- a/custom/cve5/edit.pug
+++ b/custom/cve5/edit.pug
@@ -97,6 +97,9 @@ block prepend loadEditor
         |         for (a of j.containers.cna.affected) {
         |             for (v of a.versions) {
         |                mt = mt + "- " + a.product
+        |                if (a.packageName) {
+        |                  mt = mt + " (" + a.packageName + ")"
+        |                }
         |                const openended = v.lessThan == "*" || v.lessThanOrEqual == "*"
         |                if (v.version == "0" && openended) {
         |                    mt = mt + ": all versions"


### PR DESCRIPTION
This is especially useful when the same component is known under several coordinates, as is common for Scala.

For example, a Pekko Management CVE would look like:

```
To: oss-security@lists.openwall.com
Reply-To: dev@security.apache.org
Subject: CVE-2000-19014: Apache Pekko Management, Apache Pekko Management, Apache Pekko Management: test desc

Severity:

Affected versions:

- Apache Pekko Management before 1.1.1
- Apache Pekko Management before 1.1.1
- Apache Pekko Management before 1.1.1

Description:

```

But with this change:

```
To: oss-security@lists.openwall.com
Reply-To: dev@security.apache.org
Subject: CVE-2000-19014: Apache Pekko Management, Apache Pekko Management, Apache Pekko Management: test desc

Severity:

Affected versions:

- Apache Pekko Management (org.apache.pekko:pekko-management_2.12) before 1.1.1
- Apache Pekko Management (org.apache.pekko:pekko-management_2.13) before 1.1.1
- Apache Pekko Management (org.apache.pekko:pekko-management_3) before 1.1.1

Description:

```