### PR TITLE
remove duplicates from subject

### DIFF
--- a/custom/cve5/asfpreload.js
+++ b/custom/cve5/asfpreload.js
@@ -1,7 +1,9 @@
 function getProductListNoVendor(cve) {
     var lines = [];
     for (var affected of cve.containers.cna.affected) {
-        lines.push(affected.product);
+        if (!lines.includes(affected.product)) {
+            lines.push(affected.product);
+        }
     }
     return lines.join(", ");
 }


### PR DESCRIPTION
Can happen in case of packages that are known under multiple package names, such as many Commons projects