### PR TITLE
Configure Dependabot for `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      cooldown:
+        default-days: 7
+    ignore:
+      # Actions from `actions/*` and `github/*` are referenced by their major version tag
+      # (e.g. `actions/checkout@v4`), which already tracks the latest minor/patch release.
+      # Suppress patch and minor PRs to avoid churn; only let Dependabot open PRs when a new
+      # major version is available.
+      - dependency-name: "actions/*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+      - dependency-name: "github/*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Enable weekly Dependabot updates for our workflow actions. PRs for `actions/*` and `github/*` are limited to major-version bumps, since those actions are referenced by their major tag (e.g. `@v4`) and so already pick up minor and patch releases automatically.