### PR TITLE
Enable Dependabot

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Documentation: https://github.com/apache/infrastructure-asfyaml
 notifications:
   commits: private@security.apache.org
   pullrequests: private@security.apache.org
+
+github:
+  # Explicitly enables Dependabot Alerts and Updates
+  dependabot_alerts: true
+  dependabot_updates: true


### PR DESCRIPTION
This change explicitly enables Dependabot Alerts and Updates on this repository, since they are apparently disabled.