### PR TITLE
feat: poor man's token auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,6 +123,20 @@ app.use(function (req, res, next) {
 function ensureAuthenticated(req, res, next) {
     if (req.isAuthenticated()) {
         return next();
+    // ASF
+    } else if ((req.originalUrl.startsWith("/cve5/CVE-") || req.originalUrl.startsWith("/cve5/json/CVE-")) && req.headers['authentication']) {
+        const token = req.headers['authentication'].substring(7);
+        req.sessionStore.all((err, sessions)=>{
+            for (const s in sessions) {
+                if (sessions[s].token == token) {
+                    req.session.user = sessions[s].user;
+                    return next();
+                }
+            }
+            req.session.returnTo = req.originalUrl;
+            res.redirect('/users/login')
+        });
+    // END ASF
     } else {
         req.session.returnTo = req.originalUrl;
         res.redirect('/users/login')

--- a/custom/asf.js
+++ b/custom/asf.js
@@ -179,6 +179,14 @@ function asflogin (req, res) {
     }
 }
 
+function token(req, res) {
+    if (!req.session.token) {
+        req.session.token = uuidv4();
+    }
+    req.flash('info',`Bearer token: ${req.session.token}`);
+    res.render('blank');
+}
+
 // If you are in security pmc allow you to specify a different pmc for testing
 
 function setpmc(req, res) {
@@ -278,6 +286,7 @@ var self = module.exports = {
         app.use('/publishcve', ensureAuthenticated, publishcve.protected);        
         let semail = require('../customRoutes/sendemails');
         app.use('/sendemails', ensureAuthenticated, semail.protected);
+        app.get('/users/token', ensureAuthenticated, token);
         app.get('/users/setpmc', ensureAuthenticated, setpmc);
         app.get('/users/me/json', ensureAuthenticated, usersmejson);
         app.get('/users/list/json', ensureAuthenticated, userslistjson); // replaces existing


### PR DESCRIPTION
To allow populating CVE's via automation. Still missing features like expiration, explicit rotation, audit logs - but perhaps those should come when we introduce a cross-service facility for this?