### PR TITLE
feat: show CVSS ratings in notification emails

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/custom/cve5/edit.pug
+++ b/custom/cve5/edit.pug
@@ -94,19 +94,14 @@ block prepend loadEditor
         |                     severity = severity + m.other.content.text + " "
         |                 }
         |                 var c = m.cvssV4_0 || m.cvssV3_1 || m.cvssV3_0 || m.cvssV2_0
-        |                 if (c && (c.baseScore != null || c.vectorString)) {
-        |                     cvss = cvss + "CVSS"
-        |                     if (c.version) cvss = cvss + " " + c.version
-        |                     cvss = cvss + ": "
-        |                     if (c.baseScore != null) cvss = cvss + c.baseScore
+        |                 if (c && c.vectorString) {
+        |                     var score = typeof c.baseScore == "number" ? c.baseScore.toFixed(1) : c.baseScore
+        |                     cvss = cvss + "CVSS " + c.version + ": " + score
         |                     if (c.baseSeverity) cvss = cvss + " (" + c.baseSeverity.toLowerCase() + ")"
-        |                     if (c.vectorString) cvss = cvss + " " + c.vectorString
-        |                     cvss = cvss + "\n"
+        |                     cvss = cvss + " " + c.vectorString + "\n"
         |                 }
         |             }
-        |             if (severity) mt = mt + "Severity: " + severity + "\n"
-        |             if (cvss) mt = mt + cvss
-        |             if (severity || cvss) mt = mt + "\n"
+        |             mt = mt + "Severity: " + severity + "\n" + cvss + "\n"
         |         }
         |         mt = mt + "Affected versions:\n\n"
         |         for (a of j.containers.cna.affected) {

--- a/custom/cve5/edit.pug
+++ b/custom/cve5/edit.pug
@@ -87,13 +87,26 @@ block prepend loadEditor
         |         }
         |         mt = ""
         |         if (j.containers.cna.metrics) {
-        |             mt = mt + "Severity: "
+        |             var severity = ""
+        |             var cvss = ""
         |             for (m of j.containers.cna.metrics) {
         |                 if (m.other && m.other.content && m.other.content.text) {
-        |                     mt = mt + m.other.content.text+" "
+        |                     severity = severity + m.other.content.text + " "
+        |                 }
+        |                 var c = m.cvssV4_0 || m.cvssV3_1 || m.cvssV3_0 || m.cvssV2_0
+        |                 if (c && (c.baseScore != null || c.vectorString)) {
+        |                     cvss = cvss + "CVSS"
+        |                     if (c.version) cvss = cvss + " " + c.version
+        |                     cvss = cvss + ": "
+        |                     if (c.baseScore != null) cvss = cvss + c.baseScore
+        |                     if (c.baseSeverity) cvss = cvss + " (" + c.baseSeverity.toLowerCase() + ")"
+        |                     if (c.vectorString) cvss = cvss + " " + c.vectorString
+        |                     cvss = cvss + "\n"
         |                 }
         |             }
-        |             mt = mt + "\n\n"
+        |             if (severity) mt = mt + "Severity: " + severity + "\n"
+        |             if (cvss) mt = mt + cvss
+        |             if (severity || cvss) mt = mt + "\n"
         |         }
         |         mt = mt + "Affected versions:\n\n"
         |         for (a of j.containers.cna.affected) {


### PR DESCRIPTION
Closes #166

The announcement email body only showed the ASF text severity rating. It now also prints any CVSS metric present (v4.0, v3.1, v3.0 or v2.0), one line per metric:

```
Severity: important
CVSS 4.0: 8.7 (high) CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N

Affected versions:
...
```

A record with only a CVSS metric prints just the CVSS line; a record with neither prints nothing, as before.

Verified by compiling the template with pug and running the extracted email-body snippet against ASF-only, ASF+CVSS 4.0, CVSS 3.1-only, and empty metrics.

Also bumps `codeql-action/autobuild` to v4: `init` and `analyze` were already on v4 (#206) but #218 brought back a v3 `autobuild` step, which fails every CodeQL run with `Loaded a configuration file for version '4.37.8', but running version '3.37.8'`.