### PR TITLE
ci: bump codeql-action/autobuild to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl


### PR DESCRIPTION
The CodeQL workflow has failed on every `main` run since #218: that merge brought back an `autobuild@v3` step from `main-next`, while `init` and `analyze` had already been bumped to v4 in #206. The v3 autobuild step aborts with:

```
Loaded a configuration file for version '4.37.8', but running version '3.37.8'
```

This bumps `autobuild` to v4 so all three steps match.