### PR TITLE
fix(api): allow POST via API

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ const session = require('express-session');
 const passport = require('passport');
 const crypto = require('crypto');
 const compress = require('compression');
+const csurf = require('csurf');
+var csrfProtection = csurf();
 
 if (process.cwd() !== __dirname) {
     try {
@@ -122,14 +124,21 @@ app.use(function (req, res, next) {
 // add this to route for authenticating before certain requests.
 function ensureAuthenticated(req, res, next) {
     if (req.isAuthenticated()) {
-        return next();
+        // Session (cookie) authentication is vulnerable to CSRF, so requests
+        // authenticated that way carry a CSRF token. Requests authenticated
+        // with a bearer token are not: the browser does not attach an
+        // Authorization header by itself, and we allow no cross-origin
+        // requests, so a third-party site cannot forge one.
+        return csrfProtection(req, res, next);
     // ASF
     } else if ((req.originalUrl.startsWith("/cve5/CVE-") || req.originalUrl.startsWith("/cve5/json/CVE-")) && req.headers['authorization']) {
         const token = req.headers['authorization'].substring(7);
         req.sessionStore.all((err, sessions)=>{
-            for (const s in sessions) {
+            for (const s in sessions || {}) {
                 if (sessions[s].token == token) {
-                    req.session.user = sessions[s].user;
+                    // asfinit() populates req.user from the session, but it
+                    // already ran for this request, so set it here as well.
+                    req.user = req.session.user = sessions[s].user;
                     return next();
                 }
             }

--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -1,6 +1,4 @@
 const express = require('express');
-const csurf = require('csurf');
-var csrfProtection = csurf();
 const path = require('path');
 const os = require('os');
 const Busboy = require('busboy');
@@ -34,7 +32,7 @@ module.exports = function (Document, opts) {
             return next();
         }
     }
-    router.post('/:id/file', csrfProtection, checkPattern, checkDir, async function (req, res) {
+    router.post('/:id/file', checkPattern, checkDir, async function (req, res) {
         var fq = {};
         fq[opts.idpath] = req.params.id;
         var doc = await Document.findOne(fq);
@@ -156,7 +154,7 @@ module.exports = function (Document, opts) {
     );
 
     // delete file
-    router.delete('/:id/file/:filename', csrfProtection, checkPattern, checkDir, async function (req, res) {
+    router.delete('/:id/file/:filename', checkPattern, checkDir, async function (req, res) {
         var fq = {};
         fq[opts.idpath] = req.params.id;
         // ASF

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,6 +1,4 @@
 const express = require('express');
-const csurf = require('csurf');
-var csrfProtection = csurf();
 const crypto = require('crypto');
 // ASF
 const asf = require('../custom/asf.js');
@@ -114,7 +112,7 @@ module.exports = function (Document, opts) {
         }
     }
     var router = express.Router();
-    router.post('/comment', csrfProtection, async function (req, res) {
+    router.post('/comment', async function (req, res) {
         // ASF we need to load the document so we can get the PMC
         var q = {};
         q[opts.idpath] = req.body.id;

--- a/routes/doc.js
+++ b/routes/doc.js
@@ -3,11 +3,9 @@ const docModel = require('../models/doc');
 const conf = require('../config/conf');
 const querymw = require('../lib/querymw');
 const package = require('../package.json');
-const csurf = require('csurf');
 // ASF
 const asf =  require('../custom/asf.js');
 // END ASF
-var csrfProtection = csurf();
 var querymen = require('querymen');
 var qs = require('querystring');
 const _ = require('lodash');
@@ -256,7 +254,7 @@ module.exports = function (name, opts) {
             res.json([]);
         }
     });
-    router.post('/json/', csrfProtection, async function (req, res) {
+    router.post('/json/', async function (req, res) {
         if (req.body.ids && req.body.ids.length > 0) {
             //console.log('REQ: ' + JSON.stringify(req.body.ids));
             var q = {};
@@ -511,7 +509,7 @@ module.exports = function (name, opts) {
         return pipeLine;
     };
     /* The Main listing routine */
-    router.get('/', csrfProtection, queryMW, async function (req, res) {
+    router.get('/', queryMW, async function (req, res) {
         try {
             // ASF
             var mychartCount = chartCount;
@@ -643,7 +641,7 @@ module.exports = function (name, opts) {
                 total: total,
                 columns: columns,
                 current: currentPage,
-                csrfToken: req.csrfToken(),
+                csrfToken: req.csrfToken ? req.csrfToken() : '',
                 bulkInput: bulkInput
             });
 
@@ -661,7 +659,6 @@ module.exports = function (name, opts) {
     var History = docModel(opts.historyCollectionName);
     //UPDATE many
     router.post('/update',
-        csrfProtection,
         queryMWBody,
         async function (req, res) {
             try {

--- a/routes/onedoc.js
+++ b/routes/onedoc.js
@@ -1,9 +1,7 @@
 const express = require('express');
-const csurf = require('csurf');
 // ASF
 const asf =  require('../custom/asf.js');
 // END ASF
-var csrfProtection = csurf();
 const textUtil = require('../src/js/edit/util.js');
 var jsonpatch = require('json-patch-extended');
 var _ = require('lodash');
@@ -41,7 +39,7 @@ module.exports = function (Document, opts) {
     var router = module.router = express.Router();
 
     // GET docuemnt
-    router.get('/:id', ensureRouteID, csrfProtection, [checkID], async function (req, res) {
+    router.get('/:id', ensureRouteID, [checkID], async function (req, res) {
         var q = {};
         q[opts.idpath] = req.params.id;
         try {
@@ -71,7 +69,7 @@ module.exports = function (Document, opts) {
                     doc: doc ? doc : {},
                     textUtil: textUtil,
                     doc_id: req.params.id,
-                    csrfToken: req.csrfToken(),
+                    csrfToken: req.csrfToken ? req.csrfToken() : '',
                     renderTemplate: 'default',
                     ucomments: ucomments
                 });
@@ -83,7 +81,7 @@ module.exports = function (Document, opts) {
                     idpath: opts.jsonidpath,
                     doc: doc,
                     textUtil: textUtil,
-                    csrfToken: req.csrfToken(),
+                    csrfToken: req.csrfToken ? req.csrfToken() : '',
                     allowAjax: true,
                     ucomments: ucomments
                 });
@@ -120,7 +118,7 @@ module.exports = function (Document, opts) {
     var queryMW = querymw(opts.facet);
 
     // Render a NEW editable document
-    router.get('/new', csrfProtection, queryMW, async function (req, res) {
+    router.get('/new', queryMW, async function (req, res) {
         var doc = null;
         if (req.querymen.query[opts.idpath]) {
             var fq = {};
@@ -141,7 +139,7 @@ module.exports = function (Document, opts) {
                 opts: opts,
                 idpath: opts.jsonidpath,
                 textUtil: textUtil,
-                csrfToken: req.csrfToken(),
+                csrfToken: req.csrfToken ? req.csrfToken() : '',
                 allowAjax: true
             });
         }
@@ -199,7 +197,7 @@ module.exports = function (Document, opts) {
     }
 
     // Creat a new document
-    router.post(/\/(new)$/, csrfProtection, [checkID, existCheck], async function (req, res) {
+    router.post(/\/(new)$/, [checkID, existCheck], async function (req, res) {
         let errors = validationResult(req).array();
         if (errors.length > 0) {
             var msg = 'Error: ';
@@ -239,7 +237,7 @@ module.exports = function (Document, opts) {
     });
 
     // Update or insert existing Document ID 
-    router.post('/:id', ensureRouteID, csrfProtection, [checkID], async function (req, res) {
+    router.post('/:id', ensureRouteID, [checkID], async function (req, res) {
         let errors = validationResult(req).array();
         if (errors.length > 0) {
             var msg = 'Error: ';
@@ -327,7 +325,7 @@ module.exports = function (Document, opts) {
     });
 
     //Delete Document
-    router.delete('/:id', ensureRouteID, csrfProtection, async function (req, res) {
+    router.delete('/:id', ensureRouteID, async function (req, res) {
         let query = {};
         query[opts.idpath] = req.params.id;
 


### PR DESCRIPTION
Moves the CSRF protection to app.js so that API users can use Bearer token authorization without providing a CSRF token as well.

Draft because:
* needs testing
* particularly needs double-checking whether sensitive GET endpoints are protected. If not we might want to migrate these to POST/PUT (but that'd be a separate change, perhaps also relevant to upstream)

Should fix #223 