### PR TITLE
Remove login gate on Changes tab comparison (fixes #209)

### DIFF
--- a/default/cve5/portal.js
+++ b/default/cve5/portal.js
@@ -1600,9 +1600,12 @@ async function cveFetchCurrentPortalDoc(cveId) {
             }
             return cvePreparePublishDoc(currentDoc);
         } catch (e) {
-            if (e != '404' && e.error != 'CVE_RECORD_DNE') {
-                throw e;
+            // Record genuinely doesn't exist yet: nothing to compare against.
+            if (e == '404' || (e && e.error == 'CVE_RECORD_DNE')) {
+                return null;
             }
+            // Any other failure (no active session, network issue, etc.)
+            // falls through to the public CVE.org API below.
         }
     }
     // Fall back to the public CVE.org API (no auth required).
@@ -2171,17 +2174,6 @@ async function cveRenderPublishChanges(doc) {
         await ensurePortalBootstrap();
     } catch (e) {
         cveSetPublishChangesMessage(container, cvePublishErrorMessage(e), true);
-        return;
-    }
-    var hasSession = false;
-    try {
-        hasSession = await hasActivePortalSession(csCache.url);
-    } catch (e) {
-        cveSetPublishChangesMessage(container, cvePublishErrorMessage(e), true);
-        return;
-    }
-    if (!hasSession) {
-        cveSetPublishChangesMessage(container, 'Login to CVE Services to compare against the current record.', false);
         return;
     }
     try {


### PR DESCRIPTION
Fixes #209

The "Changes" tab compared a draft against the published record, but
required an active CVE Services login even though the code already had
a fallback to the public cve.org API (no auth needed).

- Removed the `hasSession` check in `cveRenderPublishChanges()` that
  blocked the comparison with a login message.
- Widened the catch block in `cveFetchCurrentPortalDoc()` so any
  non-404 failure (e.g. no active session) falls through to the
  public cve.org API fallback, instead of throwing.